### PR TITLE
Merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ $ make -j
 
 ## Run with small dataset
 ```
-./contrib/small.sh <threads> <iterations> <back_end_nodes> <front_end_cpus>
+./contrib/small.sh <threads> <iterations> <back_end_nodes>
 ```
 Example:
 ```
-./contrib/small.sh 2 4 2 3
+./contrib/small.sh 2 4 2
 ```
 
 ## Run with large dataset
 ```
-./contrib/large.sh <threads> <iterations> <back_end_nodes> <front_end_cpus>
+./contrib/large.sh <threads> <iterations> <back_end_nodes>
 ```
 
 **Note:** both datasets must be run with *at least* 2 threads and the following environment variables must be set:

--- a/contrib/large.sh
+++ b/contrib/large.sh
@@ -16,5 +16,6 @@ export EBBRT_NODE_ALLOCATOR_DEFAULT_CPUS=$1
 export EBBRT_NODE_ALLOCATOR_DEFAULT_RAM=64
 export EBBRT_NODE_ALLOCATOR_DEFAULT_NUMANODES=1
 
-./build/reconstruction -o 3TReconstruction.nii -i data/14_3T_nody_001.nii data/10_3T_nody_001.nii data/21_3T_nody_001.nii data/23_3T_nody_001.nii -m data/mask_10_3T_brain_smooth.nii --disableBiasCorrection --useAutoTemplate --useSINCPSF --resolution 1.0 --debug ${DEBUG}  --numThreads $1 --useCPU --iterations $2 --numNodes $3 --numFrontEndCpus $4 ${TESTARGS} | tee tmp
-/tmp/ebbrt/contrib/clean_running_apps.sh
+./build/reconstruction -o 3TReconstruction.nii -i data/14_3T_nody_001.nii data/10_3T_nody_001.nii data/21_3T_nody_001.nii data/23_3T_nody_001.nii -m data/mask_10_3T_brain_smooth.nii --disableBiasCorrection --useAutoTemplate --useSINCPSF --resolution 1.0 --debug ${DEBUG}  --numThreads $1 --useCPU --iterations $2 --numNodes $3 ${TESTARGS} | tee tmp
+
+~/EbbRT/contrib/clean_running_apps.sh 1

--- a/contrib/small.sh
+++ b/contrib/small.sh
@@ -16,6 +16,6 @@ export EBBRT_NODE_ALLOCATOR_DEFAULT_CPUS=$1
 export EBBRT_NODE_ALLOCATOR_DEFAULT_RAM=4
 export EBBRT_NODE_ALLOCATOR_DEFAULT_NUMANODES=1
 
-./build/reconstruction -o 3TStackReconstruction.nii -i data/masked_stack-1.nii data/masked_stack-2.nii data/masked_stack-3.nii  data/masked_stack-4.nii --disableBiasCorrection --useAutoTemplate --useSINCPSF --resolution 2.0 --debug ${DEBUG} --numThreads $1 --useCPU --iterations $2 --numNodes $3 --numFrontEndCpus $4 ${TESTARGS} | tee tmp
+./build/reconstruction -o 3TStackReconstruction.nii -i data/masked_stack-1.nii data/masked_stack-2.nii data/masked_stack-3.nii  data/masked_stack-4.nii --disableBiasCorrection --useAutoTemplate --useSINCPSF --resolution 2.0 --debug ${DEBUG} --numThreads $1 --useCPU --iterations $2 --numNodes $3 ${TESTARGS} | tee tmp
 
-~/EbbRT/contrib/clean_running_apps.sh
+~/EbbRT/contrib/clean_running_apps.sh 1

--- a/src/hosted/irtkReconstruction.cc
+++ b/src/hosted/irtkReconstruction.cc
@@ -124,7 +124,6 @@ void irtkReconstruction::SetParameters(arguments args) {
   _recIterationsLast = args.recIterationsLast; 
   _numThreads = args.numThreads; // Not used
   _numBackendNodes = args.numBackendNodes; 
-  _numFrontendCPUs = args.numFrontendCPUs; // Not used
 
   _sigma = (args.sigma) > 0 ? args.sigma : 20;
   _resolution = args.resolution; // Not used

--- a/src/hosted/irtkReconstruction.cc
+++ b/src/hosted/irtkReconstruction.cc
@@ -179,7 +179,12 @@ ebbrt::Future<void> irtkReconstruction::ReconstructionDone() {
 }
 
 void irtkReconstruction::ReturnFrom() {
+  
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   _received++;
+  }
+
   if (_received == _numBackendNodes) {
     _received = 0;
     _future.SetValue(1);
@@ -219,7 +224,11 @@ void irtkReconstruction::AssembleImage(ebbrt::IOBuf::DataPointer & dp) {
 
 void irtkReconstruction::ReturnFromGaussianReconstruction(
     ebbrt::IOBuf::DataPointer & dp) {
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   AssembleImage(dp);
+  }
+
   ReturnFrom();
 }
 
@@ -234,15 +243,21 @@ void irtkReconstruction::ReturnFromSimulateSlices(
 
 void irtkReconstruction::ReturnFromInitializeRobustStatistics(
     ebbrt::IOBuf::DataPointer & dp) {
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   int num = dp.Get<int>();
   double sigma = dp.Get<double>();
   _sigmaSum += sigma;
   _numSum += num;
+  }
+
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepI(ebbrt::IOBuf::DataPointer & dp) {
 
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   auto parameters = dp.Get<struct eStepReturnParameters>();
 
   _sum += parameters.sum;
@@ -251,28 +266,35 @@ void irtkReconstruction::ReturnFromEStepI(ebbrt::IOBuf::DataPointer & dp) {
   _sum2 += parameters.sum2;
   _maxs = (_maxs > parameters.maxs) ? _maxs : parameters.maxs;
   _mins = (_mins < parameters.mins) ? _mins : parameters.mins;
-  
+  }
+
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepII(ebbrt::IOBuf::DataPointer & dp) {
 
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   auto parameters = dp.Get<struct eStepReturnParameters>();
 
   _sum += parameters.sum;
   _den += parameters.den;
   _den2 += parameters.den2;
   _sum2 += parameters.sum2;
+  }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepIII(ebbrt::IOBuf::DataPointer & dp) {
 
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   auto parameters = dp.Get<struct eStepReturnParameters>();
 
   _sum += parameters.sum;
   _num += parameters.num;
+  }
 
   ReturnFrom();
 }
@@ -283,6 +305,10 @@ void irtkReconstruction::ReturnFromScale(ebbrt::IOBuf::DataPointer & dp) {
 
 void irtkReconstruction::ReturnFromSuperResolution(
     ebbrt::IOBuf::DataPointer & dp) {
+
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+
   // Read addon image
   int addonSize = dp.Get<int>();
   dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
@@ -292,18 +318,22 @@ void irtkReconstruction::ReturnFromSuperResolution(
   int confidenceMapSize = dp.Get<int>();
   dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
   _confidenceMap.SumVec(_imageDoublePtr);
+  }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromMStep(ebbrt::IOBuf::DataPointer & dp) {
 
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   auto parameters = dp.Get<struct mStepReturnParameters>();
   _mSigma += parameters.sigma;
   _mMix += parameters.mix;
   _mNum += parameters.num;
   _mMax = (_mMax > parameters.max) ? _mMax : parameters.max;
   _mMin = (_mMin < parameters.min) ? _mMin : parameters.min;
+  }
 
   ReturnFrom();
 }
@@ -316,19 +346,28 @@ void irtkReconstruction::ReturnFromRestoreSliceIntensities(
 void irtkReconstruction::ReturnFromScaleVolume(
     ebbrt::IOBuf::DataPointer & dp) {
 
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   auto parameters = dp.Get<struct scaleVolumeParameters>();
   _num += parameters.num;
   _den += parameters.den;
+  }
+
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromSliceToVolumeRegistration(
     ebbrt::IOBuf::DataPointer & dp) {
+
+  {
+  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
   int start = dp.Get<int>();
   int end = dp.Get<int>();
 
   for(int i = start; i < end; i++) {
     deserializeTransformations(dp, _transformations[i]);
+  }
+
   }
 
   ReturnFrom();
@@ -1140,6 +1179,7 @@ void irtkReconstruction::Execute() {
   ScaleVolume();
 
   auto seconds = endTimer(start);
+  cout << "[Reconstruction Loop time]: " << seconds << endl;
     
   if (_debug) {
     cout << endl;

--- a/src/hosted/irtkReconstruction.cc
+++ b/src/hosted/irtkReconstruction.cc
@@ -178,15 +178,14 @@ ebbrt::Future<void> irtkReconstruction::ReconstructionDone() {
 }
 
 void irtkReconstruction::ReturnFrom() {
-  
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  _received++;
-  }
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    _received++;
 
-  if (_received == _numBackendNodes) {
-    _received = 0;
-    _future.SetValue(1);
+    if (_received == _numBackendNodes) {
+      _received = 0;
+      _future.SetValue(1);
+    }
   }
 }
 
@@ -224,8 +223,8 @@ void irtkReconstruction::AssembleImage(ebbrt::IOBuf::DataPointer & dp) {
 void irtkReconstruction::ReturnFromGaussianReconstruction(
     ebbrt::IOBuf::DataPointer & dp) {
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  AssembleImage(dp);
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    AssembleImage(dp);
   }
 
   ReturnFrom();
@@ -243,56 +242,53 @@ void irtkReconstruction::ReturnFromSimulateSlices(
 void irtkReconstruction::ReturnFromInitializeRobustStatistics(
     ebbrt::IOBuf::DataPointer & dp) {
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  int num = dp.Get<int>();
-  double sigma = dp.Get<double>();
-  _sigmaSum += sigma;
-  _numSum += num;
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    int num = dp.Get<int>();
+    double sigma = dp.Get<double>();
+    _sigmaSum += sigma;
+    _numSum += num;
   }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepI(ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  auto parameters = dp.Get<struct eStepReturnParameters>();
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto parameters = dp.Get<struct eStepReturnParameters>();
 
-  _sum += parameters.sum;
-  _den += parameters.den;
-  _den2 += parameters.den2;
-  _sum2 += parameters.sum2;
-  _maxs = (_maxs > parameters.maxs) ? _maxs : parameters.maxs;
-  _mins = (_mins < parameters.mins) ? _mins : parameters.mins;
+    _sum += parameters.sum;
+    _den += parameters.den;
+    _den2 += parameters.den2;
+    _sum2 += parameters.sum2;
+    _maxs = (_maxs > parameters.maxs) ? _maxs : parameters.maxs;
+    _mins = (_mins < parameters.mins) ? _mins : parameters.mins;
   }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepII(ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  auto parameters = dp.Get<struct eStepReturnParameters>();
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto parameters = dp.Get<struct eStepReturnParameters>();
 
-  _sum += parameters.sum;
-  _den += parameters.den;
-  _den2 += parameters.den2;
-  _sum2 += parameters.sum2;
+    _sum += parameters.sum;
+    _den += parameters.den;
+    _den2 += parameters.den2;
+    _sum2 += parameters.sum2;
   }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromEStepIII(ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  auto parameters = dp.Get<struct eStepReturnParameters>();
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto parameters = dp.Get<struct eStepReturnParameters>();
 
-  _sum += parameters.sum;
-  _num += parameters.num;
+    _sum += parameters.sum;
+    _num += parameters.num;
   }
 
   ReturnFrom();
@@ -304,34 +300,33 @@ void irtkReconstruction::ReturnFromScale(ebbrt::IOBuf::DataPointer & dp) {
 
 void irtkReconstruction::ReturnFromSuperResolution(
     ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
 
-  // Read addon image
-  int addonSize = dp.Get<int>();
-  dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
-  _addon.SumVec(_imageDoublePtr);
+    // Read addon image
+    int addonSize = dp.Get<int>();
+    dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
+    _addon.SumVec(_imageDoublePtr);
 
-  // Read confidenceMap image
-  int confidenceMapSize = dp.Get<int>();
-  dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
-  _confidenceMap.SumVec(_imageDoublePtr);
+    // Read confidenceMap image
+    int confidenceMapSize = dp.Get<int>();
+    dp.Get(addonSize*sizeof(double), (uint8_t*) _imageDoublePtr);
+    _confidenceMap.SumVec(_imageDoublePtr);
   }
 
   ReturnFrom();
 }
 
 void irtkReconstruction::ReturnFromMStep(ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  auto parameters = dp.Get<struct mStepReturnParameters>();
-  _mSigma += parameters.sigma;
-  _mMix += parameters.mix;
-  _mNum += parameters.num;
-  _mMax = (_mMax > parameters.max) ? _mMax : parameters.max;
-  _mMin = (_mMin < parameters.min) ? _mMin : parameters.min;
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto parameters = dp.Get<struct mStepReturnParameters>();
+
+    _mSigma += parameters.sigma;
+    _mMix += parameters.mix;
+    _mNum += parameters.num;
+    _mMax = (_mMax > parameters.max) ? _mMax : parameters.max;
+    _mMin = (_mMin < parameters.min) ? _mMin : parameters.min;
   }
 
   ReturnFrom();
@@ -344,12 +339,12 @@ void irtkReconstruction::ReturnFromRestoreSliceIntensities(
 
 void irtkReconstruction::ReturnFromScaleVolume(
     ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  auto parameters = dp.Get<struct scaleVolumeParameters>();
-  _num += parameters.num;
-  _den += parameters.den;
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto parameters = dp.Get<struct scaleVolumeParameters>();
+
+    _num += parameters.num;
+    _den += parameters.den;
   }
 
   ReturnFrom();
@@ -357,16 +352,14 @@ void irtkReconstruction::ReturnFromScaleVolume(
 
 void irtkReconstruction::ReturnFromSliceToVolumeRegistration(
     ebbrt::IOBuf::DataPointer & dp) {
-
   {
-  std::lock_guard<ebbrt::SpinLock> l(spinLock_);
-  int start = dp.Get<int>();
-  int end = dp.Get<int>();
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    int start = dp.Get<int>();
+    int end = dp.Get<int>();
 
-  for(int i = start; i < end; i++) {
-    deserializeTransformations(dp, _transformations[i]);
-  }
-
+    for(int i = start; i < end; i++) {
+      deserializeTransformations(dp, _transformations[i]);
+    }
   }
 
   ReturnFrom();
@@ -374,8 +367,12 @@ void irtkReconstruction::ReturnFromSliceToVolumeRegistration(
 
 void irtkReconstruction::ReturnFromGatherTimers(
     ebbrt::IOBuf::DataPointer & dp) {
-  auto phases = dp.Get<phases_data>();
-  _backend_performance.emplace_back(phases);
+  {
+    std::lock_guard<ebbrt::SpinLock> l(spinLock_);
+    auto phases = dp.Get<phases_data>();
+    _backend_performance.emplace_back(phases);
+  }
+
   ReturnFrom();
 }
 

--- a/src/hosted/irtkReconstruction.h
+++ b/src/hosted/irtkReconstruction.h
@@ -52,7 +52,6 @@ class irtkReconstruction : public ebbrt::Messagable<irtkReconstruction>,
     int _recIterationsLast; 
     int _numThreads; 
     int _numBackendNodes; 
-    int _numFrontendCPUs; 
 
     double _sigma; 
     double _resolution; 

--- a/src/hosted/irtkReconstruction.h
+++ b/src/hosted/irtkReconstruction.h
@@ -18,6 +18,8 @@
 #include <ebbrt/StaticIOBuf.h>
 #include <ebbrt/Cpu.h>
 
+#include <ebbrt/SpinLock.h>
+
 using namespace ebbrt;
 
 class irtkReconstruction : public ebbrt::Messagable<irtkReconstruction>, 
@@ -30,6 +32,8 @@ class irtkReconstruction : public ebbrt::Messagable<irtkReconstruction>,
     std::unordered_map<uint32_t, ebbrt::Promise<void>> _promise_map;
     std::mutex _m;
     uint32_t _id{0};
+
+    ebbrt::SpinLock spinLock_;
 
     // EbbRT-related parameters
     std::vector<ebbrt::Messenger::NetworkId> _nids;

--- a/src/hosted/reconstruction.cc
+++ b/src/hosted/reconstruction.cc
@@ -107,9 +107,6 @@ void parseInputParameters(int argc, char **argv) {
       ("numThreads", 
         po::value<int>(&ARGUMENTS.numThreads)->default_value(1),
         "Number of CPU threads to run for TBB")
-      ("numFrontEndCpus", 
-        po::value<int>(&ARGUMENTS.numFrontendCPUs)->default_value(1),
-        "Number of front-end EbbRT nodes")
       ("numNodes", 
         po::value<int>(&ARGUMENTS.numBackendNodes)->default_value(1),
         "Number of back-end EbbRT nodes");
@@ -469,7 +466,7 @@ int main(int argc, char **argv) {
   EXEC_NAME = argv[0];
   parseInputParameters(argc, argv);
 
-  pthread_t tid = ebbrt::Cpu::EarlyInit((size_t) ARGUMENTS.numFrontendCPUs);
+  pthread_t tid = ebbrt::Cpu::EarlyInit((size_t) ARGUMENTS.numBackendNodes + 2);
   pthread_join(tid, &status);
   
   ebbrt::Cpu::Exit(EXIT_SUCCESS);

--- a/src/hosted/reconstruction.cc
+++ b/src/hosted/reconstruction.cc
@@ -206,8 +206,13 @@ void allocateBackends(EbbRef<irtkReconstruction> reconstruction) {
                 "/bm/reconstruction.elf32";
 
   try {
+    // creates a vector of cpu id starting at InitRecon CPU + 1
+    // assumes number of fe-cpus = # of backends + 2
+    std::vector<size_t> cpu_ids(ARGUMENTS.numBackendNodes);
+    std::iota (std::begin(cpu_ids), std::end(cpu_ids), _InitReconCPU + 1);
+
     ebbrt::pool_allocator->AllocatePool(
-        bindir.string(), ARGUMENTS.numBackendNodes);
+        bindir.string(), ARGUMENTS.numBackendNodes, cpu_ids);
   } catch (std::runtime_error& e) {
     std::cerr << e.what() << std::endl;
     ebbrt::Cpu::Exit(EXIT_FAILURE);
@@ -414,6 +419,7 @@ void AppMain() {
   _InitReconCPU = (_FeIOCPU + 1) % cpu_num;
  
   auto reconstruction = irtkReconstruction::Create();
+
   allocateBackends(reconstruction);
 
   // to capture the Init Recon time

--- a/src/hosted/reconstruction.cc
+++ b/src/hosted/reconstruction.cc
@@ -472,6 +472,10 @@ int main(int argc, char **argv) {
   EXEC_NAME = argv[0];
   parseInputParameters(argc, argv);
 
+  // define FE IO and Init. Recon CPUs
+  _FeIOCPU = 0;
+  _InitReconCPU = 0;
+
   pthread_t tid = ebbrt::Cpu::EarlyInit((size_t) ARGUMENTS.numBackendNodes + 2);
   pthread_join(tid, &status);
   

--- a/src/utils.h
+++ b/src/utils.h
@@ -95,7 +95,6 @@ struct arguments {
   int recIterationsLast;
   int numThreads;
   int numBackendNodes;
-  int numFrontendCPUs;
 
   unsigned int numInputStacksTuner;
   unsigned int T1PackageSize;


### PR DESCRIPTION
- Can specify cpu_ids for PoolAllocator()
- Removes argument for # of FE CPUs
- Locks shared variables 
- outputs reconstruction loop time